### PR TITLE
Fix duplicate subfolder output

### DIFF
--- a/build/dotnet/build_app.sh
+++ b/build/dotnet/build_app.sh
@@ -380,8 +380,8 @@ function copy_to_output_dir(){
     done
 
     info_log "Copying contents of build output dir '${BUILD_OUTPUT_DIR}' to requested output directory '${OUTPUT_DIR}'..."
-    run_a_script "mkdir -p ${OUTPUT_DIR}/${subfolder}"
-    run_a_script "cp -r ${BUILD_OUTPUT_DIR}/${subfolder}* ${OUTPUT_DIR}/${subfolder}"
+    run_a_script "mkdir -p ${OUTPUT_DIR}"
+    run_a_script "cp -r ${BUILD_OUTPUT_DIR}/${subfolder} ${OUTPUT_DIR}/${subfolder}"
     info_log "...successfully copied '${BUILD_OUTPUT_DIR}' to '${OUTPUT_DIR}'. "
 
     info_log "END: ${FUNCNAME[0]}"


### PR DESCRIPTION
Update the build_app script to copy the subfolder to the output directory, instead of creating a duplicate folder and copying the subfolder.

Before it would generate paths like:
/var/spacedev/tmp/app/nuget/nuget/somepackage.nupkg

Now it'll be:
/var/spacedev/tmp/app/nuget/somepackage.nupkg