### PR TITLE
adding another pass on purge_docker if k3s restarts the pods before its installed

### DIFF
--- a/scripts/big_red_button.sh
+++ b/scripts/big_red_button.sh
@@ -81,6 +81,10 @@ function remove_k3s() {
 
     info_log "...k3s successfully removed"
 
+    info_log "...cleaned docker containers (if applicable)..."
+    purge_docker
+    info_log "...successfully cleaned docker containers (if applicable)."
+
     info_log "END: ${FUNCNAME[0]}"
 }
 


### PR DESCRIPTION
k3s may restart the pods purged by purge_docker before k3s gets uninstalled.  This adds another purge_docker pass to remove them.

Result:
![image](https://github.com/microsoft/azure-orbital-space-sdk-setup/assets/89273172/2eb40e82-ac0c-44db-b27c-4f739212f87d)
