### PR TITLE
updating source mount to be a starts with instead of exact match

### DIFF
--- a/modules/m_100_collect_container_info.sh
+++ b/modules/m_100_collect_container_info.sh
@@ -76,7 +76,7 @@ SPACEFX_UPDATE_END" --disable_log
         if [[ "$HOSTNAME" == "codespaces"* ]]; then
             run_a_script "jq <${SPACEFX_DIR}/tmp/${APP_NAME}/container_info.json -r '.[0].HostConfig.Mounts[0].Target'" CONTAINER_WORKING_DIR
         else
-            run_a_script "jq <${SPACEFX_DIR}/tmp/${APP_NAME}/container_info.json -r '.[0].Mounts[] | select(.Source == \"${HOST_FOLDER}\") | .Destination'" CONTAINER_WORKING_DIR
+            run_a_script "jq <${SPACEFX_DIR}/tmp/${APP_NAME}/container_info.json -r '.[0].Mounts[] | select(.Source | startswith(\"${HOST_FOLDER}\")) | .Destination'" CONTAINER_WORKING_DIR
         fi
 
 


### PR DESCRIPTION
![image](https://github.com/microsoft/azure-orbital-space-sdk-setup/assets/89273172/7c154255-487f-4856-a0a3-b3b33e9395ed)
