### PR TITLE
removing coresvc-registry after staging for cross-platform architecture

### DIFF
--- a/scripts/stage_spacefx.sh
+++ b/scripts/stage_spacefx.sh
@@ -183,6 +183,14 @@ function stage_coresvc_registry(){
 
     run_a_script "docker save ${_stage_registry_image_name}:${SPACEFX_VERSION_TAG} --output ${SPACEFX_DIR}/images/${ARCHITECTURE}/coresvc-registry_${SPACEFX_VERSION}.tar"
 
+    if [[ "${ARCHITECTURE}" != "${HOST_ARCHITECTURE}" ]]; then
+        info_log "Detected cross-architecture staging.  Removing non-platform coresvc-registry image from Docker..."
+        run_a_script "docker rmi ${_stage_registry_image_name}:${SPACEFX_VERSION_TAG}" --ignore_error
+        run_a_script "docker rmi ${_stage_DEST_REGISTRY}/${_stage_REGISTRY_DEST_REPO}:${SPACEFX_VERSION}" --ignore_error
+        info_log "...successfully removed non-platform coresvc-registry image from Docker."
+    fi
+
+
 
     info_log "FINISHED: ${FUNCNAME[0]}"
 }


### PR DESCRIPTION
Updating to enable staging ARM64 components on an AMD64 platform by removing the coresvc-registry from docker images when it's initially stored.

Results are a working ARM64 stage on AMD64 platform:
![image](https://github.com/microsoft/azure-orbital-space-sdk-setup/assets/89273172/a4b9c560-0eae-40e1-80dd-eeda8c5b1a20)
