### PR TITLE
removing fileserver from dev test

### DIFF
--- a/tests/dev_cluster.sh
+++ b/tests/dev_cluster.sh
@@ -93,7 +93,6 @@ if [[ ! -f "${KUBECONFIG}" ]]; then
     exit 1
 fi
 kubectl get deployment/coresvc-registry -n coresvc
-kubectl get deployment/coresvc-fileserver -n coresvc
 kubectl get deployment/coresvc-switchboard -n coresvc
 
 kubectl get deployment/hostsvc-link -n hostsvc


### PR DESCRIPTION
Coresvc-fileserver has been removed from the devenvironment.  This PR removes the check from the test.