### PR TITLE
Stable image tag calcuation

### DIFF
--- a/modules/m_60_container_registries.sh
+++ b/modules/m_60_container_registries.sh
@@ -187,7 +187,7 @@ function calculate_tag_from_channel() {
     fi
 
     if [[ "${SPACEFX_CHANNEL}" == "stable" ]]; then
-        return_tag="${tag}-stable"
+        return_tag="${tag}"
     fi
 
     if [[ "${SPACEFX_CHANNEL}" == "rc" ]]; then


### PR DESCRIPTION
image tags for `stable` channel should just be the spacefx version and whatever architecture the current environment is