### PR TITLE
Downgrade Dapr Version due to deadlocks in Dapr

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -10,6 +10,6 @@ dependencies:
     repository: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts
     condition: subcharts.smb.enabled
   - name: dapr
-    version: 1.13.5
+    version: 1.11.6
     repository: https://dapr.github.io/helm-charts
     condition: subcharts.dapr.enabled

--- a/chart/templates/_dapr.tpl
+++ b/chart/templates/_dapr.tpl
@@ -7,15 +7,9 @@ dapr.io/app-protocol:   "grpc"
 dapr.io/app-port: "50051"
 dapr.io/log-level: {{ $globalValues.dapr.logLevel | quote }}
 dapr.io/enable-api-logging: "true"
-dapr.io/app-health-probe-interval: "5"
-dapr.io/app-health-probe-timeout: "3000"
-dapr.io/app-health-threshold: "100"
 {{- if $serviceValues.debugShim }}
-dapr.io/enable-app-health-check: "true"
 dapr.io/sidecar-liveness-probe-delay-seconds: "2"
 dapr.io/sidecar-liveness-probe-period-seconds: "2"
 dapr.io/sidecar-liveness-probe-threshold: "9999"
-{{- else }}
-dapr.io/enable-app-health-check: {{ $serviceValues.appHealthCheck | quote }}
 {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -179,7 +179,6 @@ services:
       appConfig:
         - name: messageResponseTimeoutMS
           value: 15000
-      appHealthCheck: false
       appName: platform-mts
       buildService:
         dockerFile: Dockerfile.buildsvc.app
@@ -199,7 +198,6 @@ services:
       workingDir: /workspaces/platform-mts
     deployment:
       appName: platform-deployment
-      appHealthCheck: false
       buildService:
         dockerFile: Dockerfile.buildsvc.app
         contextDir: build/dotnet
@@ -256,7 +254,6 @@ services:
         - name: enableRoutingToMTS
           value: true
       appName: vth
-      appHealthCheck: false
       buildService:
         dockerFile: Dockerfile.buildsvc.app
         contextDir: build/dotnet
@@ -281,7 +278,6 @@ services:
         - name: messageResponseTimeoutMS
           value: 15000
       appName: hostsvc-sensor
-      appHealthCheck: false
       buildService:
         dockerFile: Dockerfile.buildsvc.app
         contextDir: build/dotnet
@@ -309,7 +305,6 @@ services:
         - name: allowLinksToDeploymentSvc
           value: false
       appName: hostsvc-link
-      appHealthCheck: false
       buildService:
         dockerFile: Dockerfile.buildsvc.app
         contextDir: build/dotnet
@@ -337,7 +332,6 @@ services:
         - name: writeTelemetryToLog
           value: true
       appName: hostsvc-logging
-      appHealthCheck: false
       buildService:
         dockerFile: Dockerfile.buildsvc.app
         contextDir: build/dotnet
@@ -356,7 +350,6 @@ services:
       workingDir: /workspaces/hostsvc-logging
     position:
       appName: hostsvc-position
-      appHealthCheck: false
       buildService:
         dockerFile: Dockerfile.buildsvc.app
         contextDir: build/dotnet
@@ -406,7 +399,6 @@ services:
       serviceAccount:
         enabled: false
       appContext: null
-      appHealthCheck: false
       appName: payloadappTemplate
       appGroup: payloadappGroup
       correlationId: null

--- a/config/0_spacesdk-base.yaml
+++ b/config/0_spacesdk-base.yaml
@@ -16,21 +16,21 @@ config:
   charts:
     - group: dapr
       enabled: true
-      version: 1.13.5
+      version: 1.11.6
       namespace: dapr-system
       containers:
         - registry: ghcr.io
           repository: dapr/daprd
-          tag: 1.13.5
+          tag: 1.11.6
         - registry: ghcr.io
           repository: dapr/sentry
-          tag: 1.13.5
+          tag: 1.11.6
         - registry: ghcr.io
           repository: dapr/injector
-          tag: 1.13.5
+          tag: 1.11.6
         - registry: ghcr.io
           repository: dapr/operator
-          tag: 1.13.5
+          tag: 1.11.6
     - group: smb
       enabled: false
       version: 1.15.0


### PR DESCRIPTION
* Downgrades dapr to 1.11.6 due to deadlocks when running background services outside of dapr context
* Removes app healthcheck from dapr due to deadlocks being introduced by dapr when it's enabled

Integration Tests successfully pass when using this version:
![image](https://github.com/user-attachments/assets/ad638145-abfd-44e2-bc34-47cf6cff099a)
