### PR TITLE
fix differeing architecture helm install

### DIFF
--- a/modules/m_30_app_prereqs.sh
+++ b/modules/m_30_app_prereqs.sh
@@ -228,7 +228,7 @@ function _app_install_for_helm(){
             echo "...app '${app_name}' not found at '${source}'.  Starting download from '${url}' to '${destination}'..."
             run_a_script "curl --silent --fail --create-dirs --output ${_helm_install_temp_dir}/helm-${VER_HELM}-linux-${HOST_ARCHITECTURE}.tar.gz -L ${url}" --disable_log
 
-            run_a_script "tar -xf '${_helm_install_temp_dir}/helm-${VER_HELM}-linux-${HOST_ARCHITECTURE}.tar.gz' --directory '${_helm_install_temp_dir}' linux-${ARCHITECTURE}/helm" --disable_log
+            run_a_script "tar -xf '${_helm_install_temp_dir}/helm-${VER_HELM}-linux-${HOST_ARCHITECTURE}.tar.gz' --directory '${_helm_install_temp_dir}' linux-${HOST_ARCHITECTURE}/helm" --disable_log
             run_a_script "mv ${_helm_install_temp_dir}/linux-${HOST_ARCHITECTURE}/helm ${destination}" --disable_log
             run_a_script "rm ${_helm_install_temp_dir} -rf" --disable_log
         fi


### PR DESCRIPTION
Bug was reported that from a clean host machine. If machine OS A wanted to stage and deploy Azure Space SDK for OS B, the host machine's helm install for machine OS A was filed to the wrong location under OS B architecture. This would lead to a immediate failure of install and staging seen here.

<img width="564" alt="image" src="https://github.com/user-attachments/assets/858431ca-64e5-4dd4-8b4d-611051d99617">


Fix resolves the host-machine's install of helm in the even of differing architecture staging. Successful staging from a amd64 machine for an arm64 deployment:
<img width="1911" alt="image" src="https://github.com/user-attachments/assets/731a6d91-2c7d-482d-8b95-13ad4bb1dba7">
