### PR TITLE
Container Image Build Fix - Allow for Push to a different container registry while building from GitHub

### DIFF
--- a/build/build_containerImage.sh
+++ b/build/build_containerImage.sh
@@ -348,6 +348,7 @@ function main() {
     write_parameter_to_log APP_NAME
     write_parameter_to_log DOCKERFILE
     write_parameter_to_log REPO_DIR
+    write_parameter_to_log BUILD_FROM_GITHUB
     write_parameter_to_log PUSH_ENABLED
 
     for i in "${!BUILD_ARGS[@]}"; do

--- a/build/dotnet/build_app.sh
+++ b/build/dotnet/build_app.sh
@@ -409,6 +409,7 @@ function main() {
     write_parameter_to_log BUILDDATE_VALUE
     write_parameter_to_log CONTAINER_BUILD
     write_parameter_to_log ANNOTATION_CONFIG
+    write_parameter_to_log BUILD_FROM_GITHUB
     write_parameter_to_log PUSH_ENABLED
 
     if [[ -n "${ANNOTATION_CONFIG}" ]]; then
@@ -492,7 +493,7 @@ function main() {
         local extra_cmds=""
         [[ "${PUSH_ENABLED}" == false ]] && extra_cmds="${extra_cmds} --no-push"
 
-        [[ "${BUILD_FROM_GITHUB}" == false ]] && extra_cmds="${extra_cmds} --build-from-github"
+        [[ "${BUILD_FROM_GITHUB}" == true ]] && extra_cmds="${extra_cmds} --build-from-github"
 
         run_a_script "${SPACEFX_DIR}/build/build_containerImage.sh \
                         --dockerfile ${SPACEFX_DIR}/build/dotnet/Dockerfile.app-base \

--- a/build/dotnet/build_app.sh
+++ b/build/dotnet/build_app.sh
@@ -26,6 +26,7 @@ DEVCONTAINER_JSON_FILE=".devcontainer/devcontainer.json"
 APP_NAME=""
 CONTAINER_ID=""
 DEVCONTAINER_JSON=""
+BUILD_FROM_GITHUB=false
 PUSH_ENABLED=true
 ############################################################
 # Help                                                     #
@@ -45,6 +46,7 @@ function show_help() {
    echo "--nuget-project | -n               [OPTIONAL] Relative path to a nuget project for the service (if applicable) from within the devcontainer.  Will generate a nuget package in the output directory.  Can be passed multiple times"
    echo "--no-container-build               [OPTIONAL] Do not build a container image.  This will only build nuget packages"
    echo "--devcontainer-json                [OPTIONAL] Change the path to the devcontainer.json file.  Default is '.devcontainer/devcontainer.json' in the --repo-dir path"
+   echo "--build-from-github                [OPTIONAL] If the destination container registry is different from ghcr.io/microsoft, this will force the container image to be built from the ghcr.io/microsoft container image"
    echo "--no-push                          [OPTIONAL] Do not push the built container image to the container registry.  Useful to locally build and test a container image without pushing it to the registry."
    echo "--help | -h                        [OPTIONAL] Help script (this screen)"
    echo
@@ -106,6 +108,9 @@ while [[ "$#" -gt 0 ]]; do
         -o|--output-dir)
             shift
             OUTPUT_DIR=$1
+            ;;
+        --build-from-github)
+            BUILD_FROM_GITHUB=true
             ;;
         *) echo "Unknown parameter passed: $1"; show_help ;;
     esac
@@ -486,6 +491,8 @@ function main() {
 
         local extra_cmds=""
         [[ "${PUSH_ENABLED}" == false ]] && extra_cmds="${extra_cmds} --no-push"
+
+        [[ "${BUILD_FROM_GITHUB}" == false ]] && extra_cmds="${extra_cmds} --build-from-github"
 
         run_a_script "${SPACEFX_DIR}/build/build_containerImage.sh \
                         --dockerfile ${SPACEFX_DIR}/build/dotnet/Dockerfile.app-base \


### PR DESCRIPTION
Add new feature to `build_app` and `build_containerImages` called `--build-from-github`.

This feature, when called, will always build the payload-app image from the `ghcr.io` container registry entry stored within the user's generated `spacefx-config.json`. This ensures that the application you are building is calling the Microsoft maintained `spacefx-base` container image, which serves as the base-layer docker image for all space sdk container images. 

This allows users to build new container images with `build_app` from the Github images, and still push the container image to their desired registry they have `push_enabled: true` within the containerRegistries stored within `spacefx-config.json`.